### PR TITLE
new location for numpy.isin for numpy 2

### DIFF
--- a/pytearcat/tensor/tensor.py
+++ b/pytearcat/tensor/tensor.py
@@ -5,7 +5,7 @@ Implementation of the 'Tensor' Class and helper functions
 
 import numpy as np 
 from itertools import product as iterprod
-from numpy.lib.arraysetops import isin
+from numpy import isin
 from tqdm import tqdm_notebook
 from warnings import warn
 from .core import config


### PR DESCRIPTION
Numpy 2 has finally sunsetted arraysetops. This old import breaks pytearcat on new installs since it will install the latest version of numpy. The 'new' location was introduced in numpy 1.13 which fits with your current setup.py requirement of "numpy>=1.22.0"